### PR TITLE
Bump to 6.4.0 & variables isolation for os arch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,11 @@ on:
       - 'master'
   push:
     branches:
+      - 'feature*'
       - 'feature_*'
+      - 'feature/*'
+      - 'hotfix/*'
+      - 'hotfix*'
       - 'master'
   schedule:
     - cron: '0 10 * * *'
@@ -17,12 +21,12 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.awsvault'
         fetch-depth: 0
@@ -30,6 +34,7 @@ jobs:
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       with:
+        projectBaseDir: 'darkwizard242.awsvault'
         args: >
           -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
       env:
@@ -40,23 +45,23 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.awsvault'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |
@@ -65,6 +70,7 @@ jobs:
         pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      working-directory: 'darkwizard242.awsvault'
       run: DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,19 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.awsvault'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |
@@ -31,4 +31,5 @@ jobs:
         pip3 install -U pip wheel ansible
 
     - name: Import to Ansible Galaxy.
+      working-directory: 'darkwizard242.awsvault'
       run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,23 +16,29 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 awsvault_app: aws-vault
-awsvault_version: 6.3.1
-awsvault_osarch: linux-amd64
-awsvault_dl_url: https://github.com/99designs/{{ awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_osarch }}
+awsvault_version: 6.4.0
+awsvault_os: linux
+awsvault_arch: amd64
+awsvault_dl_url: https://github.com/99designs/{{ awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_arch }}-{{ awsvault_arch }}
 awsvault_bin_path: /usr/local/bin
+awsvault_file_owner: root
+awsvault_file_group: root
 awsvault_file_mode: '0755'
 ```
 
 ### Variables table:
 
-Variable           | Value (default)                                                                                                                      | Description
------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------
-awsvault_app       | aws-vault                                                                                                                            | Defines the app to install i.e. **aws-vault**
-awsvault_version   | 6.3.1                                                                                                                                | Defined to dynamically fetch the desired version to install. Defaults to: **6.3.1**
-awsvault_osarch    | linux-amd64                                                                                                                          | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
-awsvault_dl_url    | <https://github.com/99designs/{{> awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_osarch }} | Defines URL to download the awsvault binary from.
-awsvault_bin_path  | /usr/local/bin                                                                                                                       | Defined to dynamically set the appropriate path to store awsvault binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
-awsvault_file_mode | '0755'                                                                                                                               | Mode for the binary file of aws-vault.
+Variable            | Description
+------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------
+awsvault_app        | Defines the app to install i.e. **aws-vault**
+awsvault_version    | Defined to dynamically fetch the desired version to install. Defaults to: **6.4.0**
+awsvault_os         | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
+awsvault_arch       | Defines os architecture. Used to set the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
+awsvault_dl_url     | Defines URL to download the aws-vault binary from.
+awsvault_bin_path   | Defined to dynamically set the appropriate path to store awsvault binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+awsvault_file_owner | Owner for the binary file of aws-vault.
+awsvault_file_group | Group for the binary file of aws-vault.
+awsvault_file_mode  | Mode for the binary file of aws-vault.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ awsvault_app: aws-vault
 awsvault_version: 6.3.1
 awsvault_os: linux
 awsvault_arch: amd64
-awsvault_dl_url: https://github.com/99designs/{{ awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_arch }}-{{ awsvault_arch }}
+awsvault_dl_url: https://github.com/99designs/{{ awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_os }}-{{ awsvault_arch }}
 awsvault_bin_path: /usr/local/bin
 awsvault_file_owner: root
 awsvault_file_group: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,10 @@
 
 awsvault_app: aws-vault
 awsvault_version: 6.3.1
-awsvault_osarch: linux-amd64
-awsvault_dl_url: https://github.com/99designs/{{ awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_osarch }}
+awsvault_os: linux
+awsvault_arch: amd64
+awsvault_dl_url: https://github.com/99designs/{{ awsvault_app }}/releases/download/v{{ awsvault_version }}/{{ awsvault_app }}-{{ awsvault_arch }}-{{ awsvault_arch }}
 awsvault_bin_path: /usr/local/bin
+awsvault_file_owner: root
+awsvault_file_group: root
 awsvault_file_mode: '0755'

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -5,4 +5,6 @@
   get_url:
     url: "{{ awsvault_dl_url }}"
     dest: "{{ awsvault_bin_path }}/{{ awsvault_app }}"
+    owner: "{{ awsvault_file_owner }}"
+    group: "{{ awsvault_file_group }}"
     mode: "{{ awsvault_file_mode }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -5,4 +5,6 @@
   get_url:
     url: "{{ awsvault_dl_url }}"
     dest: "{{ awsvault_bin_path }}/{{ awsvault_app }}"
+    owner: "{{ awsvault_file_owner }}"
+    group: "{{ awsvault_file_group }}"
     mode: "{{ awsvault_file_mode }}"


### PR DESCRIPTION
- Utilize github actions/checkout@v2 and Python 3.10.0 in build-and-test workflow
- Utilize github actions/checkout@v2 and Python 3.10.0 in release workflow
- Separate out variables for OS and Arch
- Set owner and group for `aws-vault` file.
- Bump `aws-vault` to 6.4.0